### PR TITLE
Add Season Filtering and User Preference Persistence

### DIFF
--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -38,7 +38,7 @@ function Dashboard() {
         try {
           let q = collection(db, 'Users', currentUser.uid, 'Pumpkins');
           if (selectedSeason) {
-            q = query(q, where('season', '==', selectedSeason));
+            q = query(q, where('season', '==', Number(selectedSeason)));
           }
           const snapshot = await getDocs(q);
           let pumpkinsData = [];

--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useContext } from 'react';
-import { auth, db, query, orderBy, limit } from '../firebase';
+import { auth, db, query, orderBy, limit, setDoc, doc } from '../firebase';
 import { useNavigate } from 'react-router-dom';
-import { collection, doc, getDocs, deleteDoc, where, setDoc, doc  } from 'firebase/firestore';
+import { collection, getDocs, deleteDoc, where } from 'firebase/firestore';
 import Dropdown from './Dropdown';
 import Spinner from './Spinner';
 import PlusIcon from './icons/PlusIcon';

--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useContext } from 'react';
 import { auth, db, query, orderBy, limit } from '../firebase';
 import { useNavigate } from 'react-router-dom';
-import { collection, getDocs, deleteDoc, where, doc, setDoc } from 'firebase/firestore';
+import { collection, getDoc, deleteDoc, where, doc, setDoc } from 'firebase/firestore';
 import Dropdown from './Dropdown';
 import Spinner from './Spinner';
 import PlusIcon from './icons/PlusIcon';
@@ -20,23 +20,23 @@ function Dashboard() {
   const [seasons, setSeasons] = useState([]);
   const navigate = useNavigate();
 
-  useEffect(() => {
-    if (currentUser) {
-      const fetchSeasonsAndPreferences = async () => {
-        const q = collection(db, 'Users', currentUser.uid, 'Pumpkins');
-        const userDoc = doc(db, 'Users', currentUser.uid);
-  
-        const [snapshot, userSnapshot] = await Promise.all([getDocs(q), getDocs(userDoc)]);
-  
-        const seasons = [...new Set(snapshot.docs.map(doc => doc.data().season))];
-        setSeasons(seasons);
-  
-        const userData = userSnapshot.data();
-        setSelectedSeason(userData.selectedSeason || '');
-      };
-      fetchSeasonsAndPreferences();
-    }
-  }, [currentUser]);
+useEffect(() => {
+  if (currentUser) {
+    const fetchSeasonsAndPreferences = async () => {
+      const q = collection(db, 'Users', currentUser.uid, 'Pumpkins');
+      const userDoc = doc(db, 'Users', currentUser.uid);
+
+      const [snapshot, userSnapshot] = await Promise.all([getDocs(q), getDoc(userDoc)]); // Use getDoc for userSnapshot
+
+      const seasons = [...new Set(snapshot.docs.map(doc => doc.data().season))];
+      setSeasons(seasons);
+
+      const userData = userSnapshot.data();
+      setSelectedSeason(userData.selectedSeason || '');
+    };
+    fetchSeasonsAndPreferences();
+  }
+}, [currentUser]);
 
   const handleSeasonChange = async (e) => {
     setSelectedSeason(e.target.value);

--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useContext } from 'react';
 import { auth, db, query, orderBy, limit } from '../firebase';
 import { useNavigate } from 'react-router-dom';
-import { collection, getDoc, deleteDoc, where, doc, setDoc } from 'firebase/firestore';
+import { collection, getDocs, deleteDoc, where, doc, setDoc, getDoc } from 'firebase/firestore';
 import Dropdown from './Dropdown';
 import Spinner from './Spinner';
 import PlusIcon from './icons/PlusIcon';

--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -22,6 +22,18 @@ function Dashboard() {
 
   useEffect(() => {
     if (currentUser) {
+      const fetchSeasons = async () => {
+        const q = collection(db, 'Users', currentUser.uid, 'Pumpkins');
+        const snapshot = await getDocs(q);
+        const seasons = [...new Set(snapshot.docs.map(doc => doc.data().season))];
+        setSeasons(seasons);
+      };
+      fetchSeasons();
+    }
+  }, [currentUser]);
+
+  useEffect(() => {
+    if (currentUser) {
       const fetchUserPreferences = async () => {
         const userDoc = doc(db, 'Users', currentUser.uid);
         const userSnapshot = await getDocs(userDoc);

--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useContext } from 'react';
-import { auth, db, query, orderBy, limit, setDoc, doc } from '../firebase';
+import { auth, db, query, orderBy, limit } from '../firebase';
 import { useNavigate } from 'react-router-dom';
-import { collection, getDocs, deleteDoc, where } from 'firebase/firestore';
+import { collection, getDocs, deleteDoc, where, doc, setDoc, query, orderBy, limit } from 'firebase/firestore';
 import Dropdown from './Dropdown';
 import Spinner from './Spinner';
 import PlusIcon from './icons/PlusIcon';

--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useContext } from 'react';
 import { auth, db, query, orderBy, limit } from '../firebase';
 import { useNavigate } from 'react-router-dom';
-import { collection, getDocs, deleteDoc, where, doc, setDoc, query, orderBy, limit } from 'firebase/firestore';
+import { collection, getDocs, deleteDoc, where, doc, setDoc } from 'firebase/firestore';
 import Dropdown from './Dropdown';
 import Spinner from './Spinner';
 import PlusIcon from './icons/PlusIcon';

--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -108,12 +108,18 @@ return (
       <h2 className="text-2xl font-bold mb-2">Welcome to your Dashboard</h2>
       {!currentUser && <Login />}
       {currentUser && <p className="mb-4">Logged in as {currentUser.email}</p>}
-      <select value={selectedSeason} onChange={e => setSelectedSeason(e.target.value)}>
+      
+      <select 
+        value={selectedSeason} 
+        onChange={e => setSelectedSeason(e.target.value)}
+        className="mt-1 block w-full py-2 px-3 border border-gray-300 bg-white rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
+      >
         <option value="">All Seasons</option>
         {seasons.map(season => (
           <option key={season} value={season}>{season}</option>
         ))}
       </select>
+
     </div>
     {currentUser && (
       <>

--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useContext } from 'react';
-import { auth, db, query, orderBy, limit, where } from '../firebase';
+import { auth, db, query, orderBy, limit } from '../firebase';
 import { useNavigate } from 'react-router-dom';
-import { collection, doc, getDocs, deleteDoc } from 'firebase/firestore';
+import { collection, doc, getDocs, deleteDoc, where } from 'firebase/firestore';
 import Dropdown from './Dropdown';
 import Spinner from './Spinner';
 import PlusIcon from './icons/PlusIcon';

--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useContext } from 'react';
-import { auth, db, query, orderBy, limit } from '../firebase';
+import { auth, db, query, orderBy, limit, where } from '../firebase';
 import { useNavigate } from 'react-router-dom';
 import { collection, doc, getDocs, deleteDoc } from 'firebase/firestore';
 import Dropdown from './Dropdown';

--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -22,25 +22,19 @@ function Dashboard() {
 
   useEffect(() => {
     if (currentUser) {
-      const fetchSeasons = async () => {
+      const fetchSeasonsAndPreferences = async () => {
         const q = collection(db, 'Users', currentUser.uid, 'Pumpkins');
-        const snapshot = await getDocs(q);
+        const userDoc = doc(db, 'Users', currentUser.uid);
+  
+        const [snapshot, userSnapshot] = await Promise.all([getDocs(q), getDocs(userDoc)]);
+  
         const seasons = [...new Set(snapshot.docs.map(doc => doc.data().season))];
         setSeasons(seasons);
-      };
-      fetchSeasons();
-    }
-  }, [currentUser]);
-
-  useEffect(() => {
-    if (currentUser) {
-      const fetchUserPreferences = async () => {
-        const userDoc = doc(db, 'Users', currentUser.uid);
-        const userSnapshot = await getDocs(userDoc);
+  
         const userData = userSnapshot.data();
         setSelectedSeason(userData.selectedSeason || '');
       };
-      fetchUserPreferences();
+      fetchSeasonsAndPreferences();
     }
   }, [currentUser]);
 


### PR DESCRIPTION
This PR introduces the ability for users to filter pumpkins by season in the dashboard. It also persists the user's selected season as a user preference in Firestore, allowing the selected season to be remembered across sessions.

Key changes:

1. Added a dropdown in the dashboard to select the season. The dropdown is populated with unique seasons from the user's pumpkins.

2. When a season is selected, the dashboard filters the displayed pumpkins to only show pumpkins from the selected season.

3. The selected season is saved to the user's document in Firestore as a user preference.

4. When the dashboard is loaded, the user's preferred season is fetched from Firestore and set as the default value for the season dropdown.

This enhancement improves the user experience by allowing users to view pumpkins from specific seasons and by remembering user preferences across sessions.